### PR TITLE
Update geocoder-php/common-http to version 4.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "geocoder-php/common-http": "^4.0",
+        "geocoder-php/common-http": "^4.5",
         "willdurand/geocoder": "^4.0"
     },
     "provide": {


### PR DESCRIPTION
Package php-http/message-factory is abandoned, you should avoid using it. Use psr/http-factory instead.